### PR TITLE
Move getter and setter require statements to post so that test error line numbers are not skewed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,6 @@ module.exports = function rewireify(file, options) {
   }
 
   var data = "";
-  var fore = "";
   var post = "";
 
   function write(buffer) {
@@ -24,17 +23,15 @@ module.exports = function rewireify(file, options) {
 
   function end() {
 
-    fore += "/* This code was injected by Rewireify */\n";
-    fore += "var __getter = require(\"" + path.join(__dirname, "__get__") + "\").toString();\n";
-    fore += "var __setter = require(\"" + path.join(__dirname, "__set__") + "\").toString();\n";
-
+    post += "/* This code was injected by Rewireify */\n";
+    post += "var __getter = require(\"" + path.join(__dirname, "__get__") + "\").toString();\n";
+    post += "var __setter = require(\"" + path.join(__dirname, "__set__") + "\").toString();\n";
     post += "\n";
     post += "eval(__getter);\n"
     post += "eval(__setter);\n"
     post += "module.exports.__get__ = __get__;\n";
     post += "module.exports.__set__ = __set__;\n";
 
-    this.queue(fore);
     this.queue(data);
     this.queue(post);
     this.queue(null);


### PR DESCRIPTION
When developing unit tests, I found that the reported error line numbers were consistently off by 3 lines.  I was able to move the fore code to the post to correct this issue.
