### PR TITLE
Inline __get__ and __set__ definitions in injection script

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,15 +22,13 @@ module.exports = function rewireify(file, options) {
   }
 
   function end() {
+    var __get__ = require(path.join(__dirname, "__get__"));
+    var __set__ = require(path.join(__dirname, "__set__"));
 
     post += "/* This code was injected by Rewireify */\n";
-    post += "var __getter = require(\"" + path.join(__dirname, "__get__") + "\").toString();\n";
-    post += "var __setter = require(\"" + path.join(__dirname, "__set__") + "\").toString();\n";
     post += "\n";
-    post += "eval(__getter);\n"
-    post += "eval(__setter);\n"
-    post += "module.exports.__get__ = __get__;\n";
-    post += "module.exports.__set__ = __set__;\n";
+    post += "module.exports.__get__ = " + __get__.toString() + ";\n";
+    post += "module.exports.__set__ = " + __set__.toString() + ";\n";
 
     this.queue(data);
     this.queue(post);

--- a/test/spec.js
+++ b/test/spec.js
@@ -16,11 +16,11 @@ vows.describe("Injecting methods").addBatch({
     },
     "to leak variables": function(err, contents) {
       assert.isNull(err);
-      assert.match(contents, /module\.exports\.__get__\s=\s__get__;/);
+      assert.match(contents, /module\.exports\.__get__\s=\sfunction\s__get__\(\).+/);
     },
     "to modify variables": function(err, contents) {
       assert.isNull(err);
-      assert.match(contents, /module\.exports\.__set__\s=\s__set__;/);
+      assert.match(contents, /module\.exports\.__set__\s=\sfunction\s__set__\(\).+/);
     }
   }
 

--- a/test/template/dependency.js
+++ b/test/template/dependency.js
@@ -1,3 +1,5 @@
+'use strict';
+
 exports.exampleMethod = function() {
   return "I am an example";
 };


### PR DESCRIPTION
Without defining **get** and **set**, most javascript runtimes will
throw an error when in strict mode, complaining about a lack of definition
for those two variables. This happens since those function declarations
are `eval`d and therefore the runtime has no way of knowing about them.

To fix this, we can simply call toString() on **get** and **set** as the
RHS of the `module.exports.__get__` and `module.exports.__set__`
assignments, respectively. This will allow this transform to work when
modules have strict mode enabled.
