### PR TITLE
Test objects for extensibility

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,8 +33,10 @@ module.exports = function rewireify(file, options) {
 
   function end() {
     post += "/* This code was injected by Rewireify */\n";
+    post += "if (typeof module.exports === 'object' && Object.isExtensible(module.exports)) {\n";
     post += "Object.defineProperty(module.exports, '__get__', { value: " + __get__ + ", writable: true });\n";
     post += "Object.defineProperty(module.exports, '__set__', { value: " + __set__ + ", writable: true });\n";
+    post += "}\n";
 
     this.queue(data);
     this.queue(post);


### PR DESCRIPTION
Attempting to extend a non-extensible object results in a type error. This PR checks that module.exports is extensible before adding __set__ and __get__.