### PR TITLE
Using modules from upstream rewire

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,8 @@ var minimatch = require("minimatch");
 var through = require("through");
 var path = require("path");
 
-var __get__ = require("rewire/lib/__get__").toString();
-var __set__ = require("rewire/lib/__set__").toString();
+var getImportGlobalsSrc = require("rewire/lib/getImportGlobalsSrc");
+var getDefinePropertySrc = require("rewire/lib/getDefinePropertySrc");
 
 console.warn("Injecting Rewireify into modules");
 
@@ -24,22 +24,26 @@ module.exports = function rewireify(file, options) {
     return through();
   }
 
+  var prefix = getImportGlobalsSrc();
+  prefix += "(function () { ";
+
   var data = "";
-  var post = "";
+  var suffix = "";
 
   function write(buffer) {
     data += buffer;
   }
 
   function end() {
-    post += "/* This code was injected by Rewireify */\n";
-    post += "if (Object.isExtensible(module.exports)) {\n";
-    post += "Object.defineProperty(module.exports, '__get__', { value: " + __get__ + ", writable: true });\n";
-    post += "Object.defineProperty(module.exports, '__set__', { value: " + __set__ + ", writable: true });\n";
-    post += "}\n";
+    suffix += "/* This code was injected by Rewireify */\n";
+    suffix += "if (Object.isExtensible(module.exports)) {\n";
+    suffix += getDefinePropertySrc()
+    suffix += "}\n";
+    suffix += "})();";
 
+    this.queue(prefix);
     this.queue(data);
-    this.queue(post);
+    this.queue(suffix);
     this.queue(null);
   }
 


### PR DESCRIPTION
Instead of calling Object.defineProperty ourselves, we are using the upstream module for it.

Part of the discussion in #17

