### PR TITLE
fixes error thrown with phantom and React 0.14

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,8 @@ module.exports = function rewireify(file, options) {
 
   function end() {
     post += "/* This code was injected by Rewireify */\n";
-    post += "if (Object.isExtensible(module.exports)) {\n";
+    post += "if ('functionobject'.match(typeof module.exports) && \n"
+    post += "Object.isExtensible(module.exports)) {\n";
     post += "Object.defineProperty(module.exports, '__get__', { value: " + __get__ + ", writable: true });\n";
     post += "Object.defineProperty(module.exports, '__set__', { value: " + __set__ + ", writable: true });\n";
     post += "}\n";

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ module.exports = function rewireify(file, options) {
 
   function end() {
     post += "/* This code was injected by Rewireify */\n";
-    post += "if ('functionobject'.match(typeof module.exports) && \n"
+    post += "if ((typeof module.exports).match(/object|function/) && \n"
     post += "Object.isExtensible(module.exports)) {\n";
     post += "Object.defineProperty(module.exports, '__get__', { value: " + __get__ + ", writable: true });\n";
     post += "Object.defineProperty(module.exports, '__set__', { value: " + __set__ + ", writable: true });\n";


### PR DESCRIPTION
When running my tape test suite through phantom with React 0.14
I get a type error 'Object.extensible can only be called on Objects"
This commit checks that module.exports is not a primitive before
calling `Object.extensible` on it.