### PR TITLE
Add istanbul ignores to rewieify-d code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,9 @@ module.exports = function rewireify(file, options) {
     post += "/* This code was injected by Rewireify */\n";
     post += "if ((typeof module.exports).match(/object|function/) && \n"
     post += "Object.isExtensible(module.exports)) {\n";
+    post += "/* istanbul ignore next */\n";
     post += "Object.defineProperty(module.exports, '__get__', { value: " + __get__ + ", writable: true });\n";
+    post += "/* istanbul ignore next */\n";
     post += "Object.defineProperty(module.exports, '__set__', { value: " + __set__ + ", writable: true });\n";
     post += "}\n";
 


### PR DESCRIPTION
When using istanbul, the code which is injected into the files is counted towards the coverage total.

By adding the following lines, the rewire-ify injected code is ignore from the coverage totals
